### PR TITLE
feat: precommit pyright basic type-checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,12 @@ repos:
         language: script
         pass_filenames: true
         files: ^(tests|custom_components)/.+\.py$
+      - id: pyright
+        name: pyright
+        entry: run_venv.sh pyright
+        language: script
+        pass_filenames: true
+        files: ^(tests|custom_components)/.+\.py$
       - id: pytest
         name: pytest
         entry: run_venv.sh pytest --no-cov

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,6 +8,7 @@ pre-commit~=2.21.0
 polyfactory~=2.9.0
 pytest-asyncio~=0.21.0
 ruff~=0.1.9
+pyright~=1.1.344
 
 # Need specific versions
 pytest==7.4.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,8 @@ warn_incomplete_stub = true
 warn_redundant_casts = true
 warn_unused_configs = true
 
+[tool.pyright]
+typeCheckingMode = "basic"
+
 [tool.ruff.lint.pycodestyle]
 max-line-length = 80


### PR DESCRIPTION
Inside the devcontainer vscode is using pyright with basic typechecking which finds some errors mypi currently doesn't find (some of them probably by configuration, as the results should be similar). This commit adds pyright to precommit which currently finds the errors at the end of this message.

Some of them can probably to be ignored by comments but for example:
~~~bash
climate.py:582:16 - error: Expression of type "str" cannot be assigned to return type "HVACMode"
    "str" is incompatible with "HVACMode" (reportGeneralTypeIssues)
~~~
could be an wrong casting to str.

If you are happy with mypy i would like to disable pyright in the dev-container and enably mypi with an vscode extension, otherwise I would just ignore or fix these errors and merge this. Either way it is worth to look some of them up.

What is your opionion?

~~~
/workspaces/mypyllant-component/custom_components/mypyllant/sensor.py
  /workspaces/mypyllant-component/custom_components/mypyllant/sensor.py:479:16 - error: Expression of type "str | dict[Unknown, Unknown] | list[Unknown] | Unknown" cannot be assigned to return type "Mapping[str, Any] | None" (reportGeneralTypeIssues)
1 error, 0 warnings, 0 informations 
0 errors, 0 warnings, 0 informations 
/workspaces/mypyllant-component/custom_components/mypyllant/climate.py
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:146:13 - error: Argument of type "dict[Required | Optional, All]" cannot be assigned to parameter "schema" of type "dict[str, Any] | Schema" in function "async_register_entity_service"
    Type "dict[Required | Optional, All]" cannot be assigned to type "dict[str, Any] | Schema"
      "dict[Required | Optional, All]" is incompatible with "dict[str, Any]"
        Type parameter "_KT@dict" is invariant, but "Required | Optional" is not the same as "str"
      "dict[Required | Optional, All]" is incompatible with "Schema" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:160:13 - error: Argument of type "dict[Required, All | Selector[Unknown]]" cannot be assigned to parameter "schema" of type "dict[str, Any] | Schema" in function "async_register_entity_service"
    Type "dict[Required, All | Selector[Unknown]]" cannot be assigned to type "dict[str, Any] | Schema"
      "dict[Required, All | Selector[Unknown]]" is incompatible with "dict[str, Any]"
        Type parameter "_KT@dict" is invariant, but "Required" is not the same as "str"
      "dict[Required, All | Selector[Unknown]]" is incompatible with "Schema" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:181:13 - error: Argument of type "dict[Optional, Coerce | All]" cannot be assigned to parameter "schema" of type "dict[str, Any] | Schema" in function "async_register_entity_service"
    Type "dict[Optional, Coerce | All]" cannot be assigned to type "dict[str, Any] | Schema"
      "dict[Optional, Coerce | All]" is incompatible with "dict[str, Any]"
        Type parameter "_KT@dict" is invariant, but "Optional" is not the same as "str"
      "dict[Optional, Coerce | All]" is incompatible with "Schema" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:199:13 - error: Argument of type "dict[Required, Selector[Unknown] | All]" cannot be assigned to parameter "schema" of type "dict[str, Any] | Schema" in function "async_register_entity_service"
    Type "dict[Required, Selector[Unknown] | All]" cannot be assigned to type "dict[str, Any] | Schema"
      "dict[Required, Selector[Unknown] | All]" is incompatible with "dict[str, Any]"
        Type parameter "_KT@dict" is invariant, but "Required" is not the same as "str"
      "dict[Required, Selector[Unknown] | All]" is incompatible with "Schema" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:221:13 - error: Argument of type "dict[Required, All | Selector[Unknown]]" cannot be assigned to parameter "schema" of type "dict[str, Any] | Schema" in function "async_register_entity_service"
    Type "dict[Required, All | Selector[Unknown]]" cannot be assigned to type "dict[str, Any] | Schema"
      "dict[Required, All | Selector[Unknown]]" is incompatible with "dict[str, Any]"
        Type parameter "_KT@dict" is invariant, but "Required" is not the same as "str"
      "dict[Required, All | Selector[Unknown]]" is incompatible with "Schema" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:241:24 - error: Expression of type "list[str]" cannot be assigned to declared type "list[HVACMode]" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:346:51 - error: Argument expression after ** must be a mapping with a "str" key type (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:348:24 - error: Argument of type "Unknown | None" cannot be assigned to parameter "program_type" of type "str" in function "set_zone_time_program"
    Type "Unknown | None" cannot be assigned to type "str"
      "None" is incompatible with "str" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:357:24 - error: Argument of type "Unknown | None" cannot be assigned to parameter "temperature" of type "float" in function "quick_veto_zone_temperature"
    Type "Unknown | None" cannot be assigned to type "float"
      "None" is incompatible with "float" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:368:24 - error: Argument of type "Unknown | None" cannot be assigned to parameter "temperature" of type "float" in function "set_manual_mode_setpoint"
    Type "Unknown | None" cannot be assigned to type "float"
      "None" is incompatible with "float" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:449:30 - error: Variable not allowed in type expression (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:449:45 - error: Variable not allowed in type expression (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:505:24 - error: Expression of type "list[str]" cannot be assigned to declared type "list[HVACMode]" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/climate.py:582:16 - error: Expression of type "str" cannot be assigned to return type "HVACMode"
    "str" is incompatible with "HVACMode" (reportGeneralTypeIssues)
14 errors, 0 warnings, 0 informations 
/workspaces/mypyllant-component/custom_components/mypyllant/__init__.py
  /workspaces/mypyllant-component/custom_components/mypyllant/__init__.py:167:22 - error: Argument of type "Any | None" cannot be assigned to parameter "year" of type "int" in function "main"
    Type "Any | None" cannot be assigned to type "int"
      "None" is incompatible with "int" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/__init__.py:203:46 - error: Argument of type "int" cannot be assigned to parameter "default" of type "Undefined" in function "__init__"
    "int" is incompatible with "Undefined" (reportGeneralTypeIssues)
/workspaces/mypyllant-component/custom_components/mypyllant/water_heater.py
  /workspaces/mypyllant-component/custom_components/mypyllant/water_heater.py:59:13 - error: Argument of type "dict[Required, All]" cannot be assigned to parameter "schema" of type "dict[str, Any] | Schema" in function "async_register_entity_service"
    Type "dict[Required, All]" cannot be assigned to type "dict[str, Any] | Schema"
      "dict[Required, All]" is incompatible with "dict[str, Any]"
        Type parameter "_KT@dict" is invariant, but "Required" is not the same as "str"
      "dict[Required, All]" is incompatible with "Schema" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/water_heater.py:66:13 - error: Argument of type "dict[Required, All]" cannot be assigned to parameter "schema" of type "dict[str, Any] | Schema" in function "async_register_entity_service"
    Type "dict[Required, All]" cannot be assigned to type "dict[str, Any] | Schema"
      "dict[Required, All]" is incompatible with "dict[str, Any]"
        Type parameter "_KT@dict" is invariant, but "Required" is not the same as "str"
      "dict[Required, All]" is incompatible with "Schema" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/water_heater.py:121:16 - error: Operator "|" not supported for types "dict[str, DHWTimeProgram]" and "str | dict[Unknown, Unknown] | list[Unknown] | Unknown"
    Operator "|" not supported for types "dict[str, DHWTimeProgram]" and "str" when expected type is "Mapping[str, Any] | None"
    Operator "|" not supported for types "dict[str, DHWTimeProgram]" and "list[Unknown]" when expected type is "Mapping[str, Any] | None" (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/water_heater.py:203:50 - error: Argument expression after ** must be a mapping with a "str" key type (reportGeneralTypeIssues)
  /workspaces/mypyllant-component/custom_components/mypyllant/water_heater.py:210:50 - error: Argument expression after ** must be a mapping with a "str" key type (reportGeneralTypeIssues)
7 errors, 0 warnings, 0 informations 
/workspaces/mypyllant-component/custom_components/mypyllant/config_flow.py
  /workspaces/mypyllant-component/custom_components/mypyllant/config_flow.py:69:21 - error: Argument of type "Literal['vaillant']" cannot be assigned to parameter "default" of type "Undefined" in function "__init__"
    "Literal['vaillant']" is incompatible with "Undefined" (reportGeneralTypeIssues)
1 error, 0 warnings, 0 informations 
/workspaces/mypyllant-component/custom_components/mypyllant/utils.py
  /workspaces/mypyllant-component/custom_components/mypyllant/utils.py:69:26 - error: "general" is not a known member of "None" (reportOptionalMemberAccess)
  /workspaces/mypyllant-component/custom_components/mypyllant/utils.py:68:52 - error: "general" is not a known member of "None" (reportOptionalMemberAccess)
2 errors, 0 warnings, 0 informations 
/workspaces/mypyllant-component/tests/test_init.py
  /workspaces/mypyllant-component/tests/test_init.py:55:12 - error: Could not access item in TypedDict
    "type" is not a required key in "FlowResult", so access may result in runtime exception (reportTypedDictNotRequiredAccess)
  /workspaces/mypyllant-component/tests/test_init.py:56:12 - error: Could not access item in TypedDict
    "step_id" is not a required key in "FlowResult", so access may result in runtime exception (reportTypedDictNotRequiredAccess)
  /workspaces/mypyllant-component/tests/test_init.py:63:12 - error: Could not access item in TypedDict
    "type" is not a required key in "FlowResult", so access may result in runtime exception (reportTypedDictNotRequiredAccess)
3 errors, 0 warnings, 0 informations
~~~