### PR TITLE
Add reachable and battery low ambisense device binary sensor

### DIFF
--- a/custom_components/mypyllant/binary_sensor.py
+++ b/custom_components/mypyllant/binary_sensor.py
@@ -51,20 +51,21 @@ async def async_setup_entry(
                 sensors.append(
                     lambda: ZoneIsManualCoolingActive(index, zone_index, coordinator)
                 )
-        for room_index, room in enumerate(system.ambisense_rooms):
-            for device in room.room_configuration.devices:
-                if device.unreach is not None:
-                    sensors.append(
-                        lambda: AmbisenseDeviceLowBattery(
-                            index, room_index, device, coordinator
+        if system.ambisense_rooms:
+            for room_index, room in enumerate(system.ambisense_rooms):
+                for device in room.room_configuration.devices:
+                    if device.unreach is not None:
+                        sensors.append(
+                            lambda: AmbisenseDeviceLowBattery(
+                                index, room_index, device, coordinator
+                            )
                         )
-                    )
-                if device.low_bat is not None:
-                    sensors.append(
-                        lambda: AmbisenseDeviceUnreachable(
-                            index, room_index, device, coordinator
+                    if device.low_bat is not None:
+                        sensors.append(
+                            lambda: AmbisenseDeviceUnreachable(
+                                index, room_index, device, coordinator
+                            )
                         )
-                    )
 
     async_add_entities(sensors)  # type: ignore
 

--- a/custom_components/mypyllant/binary_sensor.py
+++ b/custom_components/mypyllant/binary_sensor.py
@@ -371,7 +371,7 @@ class AmbisenseDeviceUnreachable(AmbisenseDeviceCoordinatorEntity, BinarySensorE
 
     @property
     def unique_id(self) -> str:
-        return self.unique_id_fragment + "unreach"
+        return self.unique_id_fragment + "_unreach"
 
     @property
     def name(self) -> str:

--- a/custom_components/mypyllant/binary_sensor.py
+++ b/custom_components/mypyllant/binary_sensor.py
@@ -13,11 +13,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from myPyllant.models import Circuit, System
+from myPyllant.models import Circuit, System, AmbisenseDevice
 
 from . import SystemCoordinator
 from .const import DOMAIN
-from .utils import EntityList, ZoneCoordinatorEntity
+from .utils import EntityList, ZoneCoordinatorEntity, AmbisenseDeviceCoordinatorEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,6 +51,20 @@ async def async_setup_entry(
                 sensors.append(
                     lambda: ZoneIsManualCoolingActive(index, zone_index, coordinator)
                 )
+        for room_index, room in enumerate(system.ambisense_rooms):
+            for device in room.room_configuration.devices:
+                if device.unreach is not None:
+                    sensors.append(
+                        lambda: AmbisenseDeviceLowBattery(
+                            index, room_index, device, coordinator
+                        )
+                    )
+                if device.low_bat is not None:
+                    sensors.append(
+                        lambda: AmbisenseDeviceUnreachable(
+                            index, room_index, device, coordinator
+                        )
+                    )
 
     async_add_entities(sensors)  # type: ignore
 
@@ -312,3 +326,57 @@ class ZoneIsManualCoolingActive(ZoneCoordinatorEntity, BinarySensorEntity):
     @property
     def unique_id(self) -> str:
         return f"{DOMAIN} {self.id_infix}_manual_cooling_active"
+
+
+class AmbisenseDeviceLowBattery(AmbisenseDeviceCoordinatorEntity, BinarySensorEntity):
+    def __init__(
+        self,
+        system_index: int,
+        room_index: int,
+        device: AmbisenseDevice,
+        coordinator: SystemCoordinator,
+    ) -> None:
+        super().__init__(system_index, room_index, device, coordinator)
+
+    @property
+    def is_on(self) -> bool | None:
+        return self.device.low_bat
+
+    @property
+    def unique_id(self) -> str:
+        return self.unique_id_fragment + "_low_bat"
+
+    @property
+    def name(self) -> str:
+        return f"{self.name_prefix} battery low"
+
+    @property
+    def device_class(self) -> BinarySensorDeviceClass:
+        return BinarySensorDeviceClass.BATTERY
+
+
+class AmbisenseDeviceUnreachable(AmbisenseDeviceCoordinatorEntity, BinarySensorEntity):
+    def __init__(
+        self,
+        system_index: int,
+        room_index: int,
+        device: AmbisenseDevice,
+        coordinator: SystemCoordinator,
+    ) -> None:
+        super().__init__(system_index, room_index, device, coordinator)
+
+    @property
+    def is_on(self) -> bool | None:
+        return not self.device.unreach
+
+    @property
+    def unique_id(self) -> str:
+        return self.unique_id_fragment + "unreach"
+
+    @property
+    def name(self) -> str:
+        return f"{self.name_prefix} reachable"
+
+    @property
+    def device_class(self) -> BinarySensorDeviceClass:
+        return BinarySensorDeviceClass.CONNECTIVITY

--- a/custom_components/mypyllant/binary_sensor.py
+++ b/custom_components/mypyllant/binary_sensor.py
@@ -13,11 +13,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from myPyllant.models import Circuit, System, AmbisenseDevice
+from myPyllant.models import System, AmbisenseDevice
 
 from . import SystemCoordinator
 from .const import DOMAIN
-from .utils import EntityList, ZoneCoordinatorEntity, AmbisenseDeviceCoordinatorEntity, CircuitEntity
+from .utils import (
+    EntityList,
+    ZoneCoordinatorEntity,
+    AmbisenseDeviceCoordinatorEntity,
+    CircuitEntity,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/mypyllant/utils.py
+++ b/custom_components/mypyllant/utils.py
@@ -356,9 +356,7 @@ class AmbisenseCoordinatorEntity(CoordinatorEntity):
         return f"{DOMAIN}_{self.id_infix}_climate"
 
 
-class AmbisenseDeviceCoordinatorEntity(CoordinatorEntity):
-    coordinator: SystemCoordinator
-
+class AmbisenseDeviceCoordinatorEntity(AmbisenseCoordinatorEntity):
     def __init__(
         self,
         system_index: int,
@@ -366,20 +364,8 @@ class AmbisenseDeviceCoordinatorEntity(CoordinatorEntity):
         device: AmbisenseDevice,
         coordinator: SystemCoordinator,
     ) -> None:
-        super().__init__(coordinator)
-        self.system_index = system_index
-        self.room_index = room_index
+        super().__init__(system_index, room_index, coordinator)
         self.device = device
-
-    @property
-    def system(self) -> System:
-        return self.coordinator.data[self.system_index]
-
-    @property
-    def room(self) -> AmbisenseRoom:
-        return [
-            r for r in self.system.ambisense_rooms if r.room_index == self.room_index
-        ][0]
 
     @property
     def name_prefix(self) -> str:
@@ -388,14 +374,6 @@ class AmbisenseDeviceCoordinatorEntity(CoordinatorEntity):
     @property
     def id_infix(self) -> str:
         return f"{self.system.id}_room_{self.room_index}_device_{self.device.sgtin}"
-
-    @property
-    def device_info(self):
-        return DeviceInfo(
-            identifiers={(DOMAIN, self.id_infix)},
-            name=self.name_prefix,
-            manufacturer=self.system.brand_name,
-        )
 
     @property
     def unique_id_fragment(self) -> str:

--- a/custom_components/mypyllant/utils.py
+++ b/custom_components/mypyllant/utils.py
@@ -29,7 +29,7 @@ if typing.TYPE_CHECKING:
         AmbisenseDevice,
         Circuit,
     )
-  
+
 logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
@@ -380,7 +380,7 @@ class AmbisenseDeviceCoordinatorEntity(AmbisenseCoordinatorEntity):
     def unique_id_fragment(self) -> str:
         return f"{DOMAIN}_{self.id_infix}"
 
-      
+
 class CircuitEntity(CoordinatorEntity):
     def __init__(
         self,


### PR DESCRIPTION
For each ambisense devices, this PR adds:
- one binary_sensor for battery_low (`false` = OK, `true` = battery low)
- one binary_sensor for unreach (`false` = unreachable, `true` = OK).


Tested with my steup (with ambisense). It could be nice if it could be tested without ambisense