### PR TITLE
New system sensors: system_flow_temperature  and energy_manager_state 

### DIFF
--- a/custom_components/mypyllant/sensor.py
+++ b/custom_components/mypyllant/sensor.py
@@ -87,6 +87,10 @@ async def create_system_sensors(
             sensors.append(
                 lambda: SystemBottomCHTemperatureSensor(index, system_coordinator)
             )
+        if system.system_flow_temperature is not None:
+            sensors.append(
+                lambda: SystemFlowTemperatureSensor(index, system_coordinator)
+            )
         sensors.append(lambda: HomeEntity(index, system_coordinator))
 
         for device_index, device in enumerate(system.devices):
@@ -1127,3 +1131,25 @@ class SystemAPIRequestCount(SensorEntity, CoordinatorEntity):
     @property
     def name(self):
         return "Vaillant API Request Count"
+
+
+class SystemFlowTemperatureSensor(SystemSensor):
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def native_value(self):
+        if self.system.system_flow_temperature is not None:
+            return round(self.system.system_flow_temperature, 1)
+        else:
+            return None
+
+    @property
+    def unique_id(self) -> str:
+        return f"{DOMAIN}_{self.id_infix}_system_flow_temperature"
+
+    @property
+    def name(self):
+        return f"{self.name_prefix} System Flow Temperature"

--- a/custom_components/mypyllant/sensor.py
+++ b/custom_components/mypyllant/sensor.py
@@ -91,6 +91,10 @@ async def create_system_sensors(
             sensors.append(
                 lambda: SystemFlowTemperatureSensor(index, system_coordinator)
             )
+        if system.energy_manager_state is not None:
+            sensors.append(
+                lambda: SystemEnergyManagerStateSensor(index, system_coordinator)
+            )
         sensors.append(lambda: HomeEntity(index, system_coordinator))
 
         for device_index, device in enumerate(system.devices):
@@ -1153,3 +1157,19 @@ class SystemFlowTemperatureSensor(SystemSensor):
     @property
     def name(self):
         return f"{self.name_prefix} System Flow Temperature"
+
+
+class SystemEnergyManagerStateSensor(SystemSensor):
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def native_value(self):
+        return self.system.energy_manager_state
+
+    @property
+    def unique_id(self) -> str:
+        return f"{DOMAIN}_{self.id_infix}_energy_manager_state"
+
+    @property
+    def name(self):
+        return f"{self.name_prefix} Energy Manager State"


### PR DESCRIPTION
I am currently investigating an inefficiency in my heating setup and suspect it to be a problem related to the hot water program. 

My setup was built a bit inefficient in my opinion: A heatpump and an electrical heater both heat up a buffer storage. The buffer storage then loads the heater and the hot water at different times: For hot water it heats up, later for regular heating it lets it temperature lower. 

In this setup, the system_flow_temperature is the buffer temperature which is of high interest in my analysis and hence I'd like to have it included. Same goes for energy_manager_state which indicates if the overall system is currently working on heating or producing hot water. 

For this plugin to work, first https://github.com/signalkraft/myPyllant/pull/136 must be merged.