### PR TITLE
Set device class for SystemDevicePowerSensor

### DIFF
--- a/custom_components/mypyllant/sensor.py
+++ b/custom_components/mypyllant/sensor.py
@@ -1106,6 +1106,7 @@ class SystemDeviceCurrentPowerSensor(SystemDeviceSensor):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_device_class = SensorDeviceClass.POWER
 
     @property
     def native_value(self):


### PR DESCRIPTION
Necessary to use the sensor as input for energy integral helper.

This way you can calculate the energy usage locally.