### PR TITLE
fix: coordinator recovery after quota exceeded and API down

### DIFF
--- a/custom_components/mypyllant/coordinator.py
+++ b/custom_components/mypyllant/coordinator.py
@@ -125,6 +125,12 @@ class MyPyllantCoordinator(DataUpdateCoordinator):
     def _quota_exc_info(self):
         del self.hass_data[self._quota_exc_info_key]
 
+    def _clear_quota_state(self) -> None:
+        """Clear all quota-related state to allow fresh retries."""
+        self._quota_hit_time = None
+        self._quota_end_time = None
+        self._quota_exc_info = None
+
     async def _refresh_session(self):
         if (
             self.api.oauth_session_expires is None
@@ -195,12 +201,12 @@ class MyPyllantCoordinator(DataUpdateCoordinator):
         if not self._quota_hit_time:
             return
 
-        time_elapsed = (dt.now(timezone.utc) - self._quota_hit_time).seconds
+        time_elapsed = (dt.now(timezone.utc) - self._quota_hit_time).total_seconds()
 
         if is_quota_exceeded_exception(self._quota_exc_info):
             _LOGGER.debug(
                 "Quota was hit %ss ago on %s by %s",
-                time_elapsed,
+                int(time_elapsed),
                 self._quota_hit_time,
                 self.__class__,
                 exc_info=self._quota_exc_info,
@@ -208,31 +214,55 @@ class MyPyllantCoordinator(DataUpdateCoordinator):
             if self._quota_end_time:
                 # If the API responded with an end time, we use that instead of the default QUOTA_PAUSE_INTERVAL
                 if dt.now(timezone.utc) < self._quota_end_time:
-                    remaining = (self._quota_end_time - dt.now(timezone.utc)).seconds
+                    remaining = int((self._quota_end_time - dt.now(timezone.utc)).total_seconds())
                     raise UpdateFailed(
                         f"{self._quota_exc_info.message} on {self._quota_exc_info.request_info.real_url}, "  # type: ignore
                         f"skipping update of myVAILLANT {self.__class__.__name__} for another"
                         f" {remaining}s"
                     ) from self._quota_exc_info
+                else:
+                    # Quota backoff period has expired, clear state and allow retry
+                    _LOGGER.info(
+                        "Quota backoff expired for %s, clearing quota state and resuming updates",
+                        self.__class__.__name__,
+                    )
+                    self._clear_quota_state()
+                    return
             elif time_elapsed < QUOTA_PAUSE_INTERVAL:
                 # No end time provided, use default interval
                 raise UpdateFailed(
                     f"{self._quota_exc_info.message} on {self._quota_exc_info.request_info.real_url}, "  # type: ignore
                     f"skipping update of myVAILLANT {self.__class__.__name__} for another"
-                    f" {QUOTA_PAUSE_INTERVAL - time_elapsed}s"
+                    f" {int(QUOTA_PAUSE_INTERVAL - time_elapsed)}s"
                 ) from self._quota_exc_info
+            else:
+                # Default backoff period has expired, clear state and allow retry
+                _LOGGER.info(
+                    "Quota backoff expired for %s (no end time), clearing quota state and resuming updates",
+                    self.__class__.__name__,
+                )
+                self._clear_quota_state()
+                return
         else:
             _LOGGER.debug(
                 "myVAILLANT API is down since %ss (%s)",
-                time_elapsed,
+                int(time_elapsed),
                 self._quota_hit_time,
                 exc_info=self._quota_exc_info,
             )
             if time_elapsed < API_DOWN_PAUSE_INTERVAL:
                 raise UpdateFailed(
                     f"myVAILLANT API is down, skipping update of myVAILLANT {self.__class__.__name__} for another"
-                    f" {API_DOWN_PAUSE_INTERVAL - time_elapsed}s"
+                    f" {int(API_DOWN_PAUSE_INTERVAL - time_elapsed)}s"
                 ) from self._quota_exc_info
+            else:
+                # API down backoff has expired, clear state and allow retry
+                _LOGGER.info(
+                    "API down backoff expired for %s, clearing state and resuming updates",
+                    self.__class__.__name__,
+                )
+                self._clear_quota_state()
+                return
 
 
 class SystemCoordinator(MyPyllantCoordinator):
@@ -287,6 +317,8 @@ class SystemCoordinator(MyPyllantCoordinator):
                     self.homes,
                 )
             ]
+            # Clear quota state on successful fetch so future updates aren't blocked
+            self._clear_quota_state()
             return data
         except ClientResponseError as e:
             self._set_quota_and_raise(e)
@@ -352,6 +384,8 @@ class DailyDataCoordinator(MyPyllantCoordinator):
                     data[system.id]["devices_data"].append(
                         [da async for da in device_data]
                     )
+            # Clear quota state on successful fetch so future updates aren't blocked
+            self._clear_quota_state()
             return data
         except ClientResponseError as e:
             self._set_quota_and_raise(e)

--- a/custom_components/mypyllant/coordinator.py
+++ b/custom_components/mypyllant/coordinator.py
@@ -214,7 +214,9 @@ class MyPyllantCoordinator(DataUpdateCoordinator):
             if self._quota_end_time:
                 # If the API responded with an end time, we use that instead of the default QUOTA_PAUSE_INTERVAL
                 if dt.now(timezone.utc) < self._quota_end_time:
-                    remaining = int((self._quota_end_time - dt.now(timezone.utc)).total_seconds())
+                    remaining = int(
+                        (self._quota_end_time - dt.now(timezone.utc)).total_seconds()
+                    )
                     raise UpdateFailed(
                         f"{self._quota_exc_info.message} on {self._quota_exc_info.request_info.real_url}, "  # type: ignore
                         f"skipping update of myVAILLANT {self.__class__.__name__} for another"

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -151,11 +151,11 @@ async def test_quota_state_cleared_after_recovery(
     """
     quota_exception = ClientResponseError(
         request_info=RequestInfo(
-            url="https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1/homes",
+            url="https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1/homes",  # type: ignore
             method="GET",
-            headers=None,
+            headers=None,  # type: ignore
         ),
-        history=None,
+        history=None,  # type: ignore
         status=403,
         message='{ "statusCode": 403, "message": "Out of call volume quota. Quota will be replenished in 00:30:00." }',
     )
@@ -207,19 +207,17 @@ async def test_quota_elapsed_time_uses_total_seconds(
     """
     quota_exception = ClientResponseError(
         request_info=RequestInfo(
-            url="https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1/homes",
+            url="https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1/homes",  # type: ignore
             method="GET",
-            headers=None,
+            headers=None,  # type: ignore
         ),
-        history=None,
+        history=None,  # type: ignore
         status=403,
         message="Quota Exceeded",
     )
 
     # Hit quota far in the past (>1 hour ago, which would wrap with .seconds)
-    with freeze_time(
-        datetime.now(timezone.utc) - timedelta(hours=2)
-    ):
+    with freeze_time(datetime.now(timezone.utc) - timedelta(hours=2)):
         with mypyllant_aioresponses(raise_exception=quota_exception) as _:
             with pytest.raises(UpdateFailed, match=r"Quota.*"):
                 await system_coordinator_mock._async_update_data()
@@ -284,11 +282,11 @@ async def test_multiple_quota_hits_then_recovery(
     """
     quota_exception = ClientResponseError(
         request_info=RequestInfo(
-            url="https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1/homes",
+            url="https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1/homes",  # type: ignore
             method="GET",
-            headers=None,
+            headers=None,  # type: ignore
         ),
-        history=None,
+        history=None,  # type: ignore
         status=403,
         message='{ "statusCode": 403, "message": "Out of call volume quota. Quota will be replenished in 00:10:00." }',
     )

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -138,3 +138,180 @@ async def test_api_down(
                 await system_coordinator_mock._async_update_data()
             )
     await mocked_api.aiohttp_session.close()
+
+
+async def test_quota_state_cleared_after_recovery(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI, system_coordinator_mock
+):
+    """After quota backoff expires and a successful fetch, quota state must be fully cleared.
+
+    Regression test: previously, _quota_hit_time was never cleared after recovery,
+    causing the coordinator to enter a terminal state where it stopped scheduling
+    updates. See https://github.com/signalkraft/mypyllant-component/issues/424
+    """
+    quota_exception = ClientResponseError(
+        request_info=RequestInfo(
+            url="https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1/homes",
+            method="GET",
+            headers=None,
+        ),
+        history=None,
+        status=403,
+        message='{ "statusCode": 403, "message": "Out of call volume quota. Quota will be replenished in 00:30:00." }',
+    )
+
+    # Step 1: Hit quota
+    with freeze_time(datetime.now(timezone.utc) - timedelta(seconds=40 * 60)):
+        with mypyllant_aioresponses(raise_exception=quota_exception) as _:
+            with pytest.raises(UpdateFailed, match=r"Quota.*"):
+                await system_coordinator_mock._async_update_data()
+
+    # Verify quota state is set
+    assert system_coordinator_mock._quota_hit_time is not None
+    assert system_coordinator_mock._quota_end_time is not None
+    assert system_coordinator_mock._quota_exc_info is not None
+
+    # Step 2: Recover after backoff expires
+    with mypyllant_aioresponses(test_data=list_test_data()[0]) as _:
+        system_coordinator_mock.data = (
+            await system_coordinator_mock._async_update_data()
+        )
+
+    # Step 3: Verify quota state is fully cleared
+    assert system_coordinator_mock._quota_hit_time is None, (
+        "_quota_hit_time should be cleared after successful recovery"
+    )
+    assert system_coordinator_mock._quota_end_time is None, (
+        "_quota_end_time should be cleared after successful recovery"
+    )
+    assert system_coordinator_mock._quota_exc_info is None, (
+        "_quota_exc_info should be cleared after successful recovery"
+    )
+
+    # Step 4: A second successful fetch should work without any quota interference
+    with mypyllant_aioresponses(test_data=list_test_data()[0]) as _:
+        system_coordinator_mock.data = (
+            await system_coordinator_mock._async_update_data()
+        )
+
+    await mocked_api.aiohttp_session.close()
+
+
+async def test_quota_elapsed_time_uses_total_seconds(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI, system_coordinator_mock
+):
+    """Elapsed time must use total_seconds(), not .seconds which wraps at 3600.
+
+    Regression test: .seconds on a timedelta wraps modulo 3600, so a 2-hour
+    elapsed time would appear as 0 seconds, incorrectly blocking recovery.
+    """
+    quota_exception = ClientResponseError(
+        request_info=RequestInfo(
+            url="https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1/homes",
+            method="GET",
+            headers=None,
+        ),
+        history=None,
+        status=403,
+        message="Quota Exceeded",
+    )
+
+    # Hit quota far in the past (>1 hour ago, which would wrap with .seconds)
+    with freeze_time(
+        datetime.now(timezone.utc) - timedelta(hours=2)
+    ):
+        with mypyllant_aioresponses(raise_exception=quota_exception) as _:
+            with pytest.raises(UpdateFailed, match=r"Quota.*"):
+                await system_coordinator_mock._async_update_data()
+
+    # After QUOTA_PAUSE_INTERVAL (3 hours), should recover even though
+    # .seconds would have wrapped (7200 % 3600 = 0)
+    with freeze_time(
+        datetime.now(timezone.utc) + timedelta(seconds=QUOTA_PAUSE_INTERVAL + 60)
+    ):
+        with mypyllant_aioresponses(test_data=list_test_data()[0]) as _:
+            # This should NOT raise — the backoff period has expired
+            system_coordinator_mock.data = (
+                await system_coordinator_mock._async_update_data()
+            )
+
+    await mocked_api.aiohttp_session.close()
+
+
+async def test_api_down_state_cleared_after_recovery(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI, system_coordinator_mock
+):
+    """After API down backoff expires and recovery succeeds, state must be cleared.
+
+    Regression test: stale _quota_hit_time from API down events was never cleared,
+    potentially blocking future updates.
+    """
+    # Step 1: API goes down
+    with mypyllant_aioresponses(raise_exception=CancelledError()) as _:
+        with pytest.raises(UpdateFailed, match=r"myVAILLANT API is down.*"):
+            await system_coordinator_mock._async_update_data()
+
+    assert system_coordinator_mock._quota_hit_time is not None
+
+    # Step 2: Recover after backoff
+    with freeze_time(
+        datetime.now(timezone.utc) + timedelta(seconds=(API_DOWN_PAUSE_INTERVAL + 10))
+    ):
+        with mypyllant_aioresponses(test_data=list_test_data()[0]) as _:
+            system_coordinator_mock.data = (
+                await system_coordinator_mock._async_update_data()
+            )
+
+    # Step 3: State should be fully cleared
+    assert system_coordinator_mock._quota_hit_time is None, (
+        "_quota_hit_time should be cleared after API recovery"
+    )
+    assert system_coordinator_mock._quota_exc_info is None, (
+        "_quota_exc_info should be cleared after API recovery"
+    )
+
+    await mocked_api.aiohttp_session.close()
+
+
+async def test_multiple_quota_hits_then_recovery(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI, system_coordinator_mock
+):
+    """After multiple consecutive quota errors, coordinator must still recover.
+
+    Regression test: simulates the real-world scenario where 5 consecutive
+    quota errors caused the coordinator to enter a terminal state.
+    See RCA for incident 2026-04-06.
+    """
+    quota_exception = ClientResponseError(
+        request_info=RequestInfo(
+            url="https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1/homes",
+            method="GET",
+            headers=None,
+        ),
+        history=None,
+        status=403,
+        message='{ "statusCode": 403, "message": "Out of call volume quota. Quota will be replenished in 00:10:00." }',
+    )
+
+    # Hit quota 5 times in succession (simulating real incident)
+    for i in range(5):
+        offset = i * 3 * 60  # 3 minutes apart
+        with freeze_time(
+            datetime.now(timezone.utc) - timedelta(seconds=40 * 60 - offset)
+        ):
+            with mypyllant_aioresponses(raise_exception=quota_exception) as _:
+                with pytest.raises(UpdateFailed, match=r"Quota.*"):
+                    await system_coordinator_mock._async_update_data()
+
+    # After all backoff periods expire, coordinator must recover
+    with mypyllant_aioresponses(test_data=list_test_data()[0]) as _:
+        system_coordinator_mock.data = (
+            await system_coordinator_mock._async_update_data()
+        )
+
+    # Quota state must be fully cleared
+    assert system_coordinator_mock._quota_hit_time is None
+    assert system_coordinator_mock._quota_end_time is None
+    assert system_coordinator_mock._quota_exc_info is None
+
+    await mocked_api.aiohttp_session.close()


### PR DESCRIPTION
After hitting the Vaillant API quota (403), the coordinator enters a terminal state where it stops scheduling updates, requiring an HA restart to recover. Observed in a real incident: 19.5-hour outage despite quota replenishing in ~30 minutes.

**Three fixes:**

1. **`.seconds` → `.total_seconds()`** — elapsed time calculation no longer wraps at 3600 seconds
2. **Explicit state clearing after backoff expires** — `_clear_quota_state()` resets `_quota_hit_time`, `_quota_end_time`, `_quota_exc_info` when the backoff window passes
3. **State clearing on successful fetch** — both `SystemCoordinator` and `DailyDataCoordinator` reset quota state after a successful API response

**4 regression tests** covering: state clearing after recovery, `.total_seconds()` correctness, API-down recovery, and 5-consecutive-error recovery.

Fixes #424, relates to #366, #382, #419, #421, #426