### PR TITLE
feat: prefer Retry-After header for quota backoff duration

### DIFF
--- a/custom_components/mypyllant/utils.py
+++ b/custom_components/mypyllant/utils.py
@@ -227,12 +227,27 @@ def is_quota_exceeded_exception(exc_info: BaseException | None) -> bool:
 
 def extract_quota_duration(exc_info: BaseException | None) -> int | None:
     """
-    Extracts the time in seconds form an error message like "Quota will be replenished in 00:44:41."
+    Extracts the quota backoff time in seconds.
+
+    Prefers the standard Retry-After response header (RFC 7231 §7.1.3) when
+    present, then falls back to parsing the body text for the Vaillant-specific
+    "Quota will be replenished in HH:MM:SS" message.
     """
     if not isinstance(exc_info, ClientResponseError) or not is_quota_exceeded_exception(
         exc_info
     ):
         return None
+
+    # Prefer the Retry-After header when available
+    retry_after = getattr(exc_info, "headers", None)
+    if retry_after is not None:
+        retry_after = retry_after.get("Retry-After")
+    if retry_after is not None:
+        try:
+            return int(retry_after)
+        except (ValueError, TypeError):
+            pass
+
     import re
 
     match = re.search(

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -74,6 +74,73 @@ async def test_quota_time_extraction(
     assert extract_quota_duration(quota_exception) == 30 * 60 + 2
 
 
+async def test_quota_duration_from_retry_after_header():
+    """Retry-After header should be preferred over parsing the body text.
+
+    See https://github.com/signalkraft/mypyllant-component/issues/366
+    """
+    exc = ClientResponseError(
+        request_info=RequestInfo(
+            url="https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1/homes",  # type: ignore
+            method="GET",
+            headers=None,  # type: ignore
+        ),
+        history=None,  # type: ignore
+        status=403,
+        message="Quota Exceeded",
+        headers={"Retry-After": "1800"},  # type: ignore
+    )
+    assert extract_quota_duration(exc) == 1800
+
+
+async def test_quota_duration_retry_after_takes_precedence_over_body():
+    """When both Retry-After header and body text are present, header wins."""
+    exc = ClientResponseError(
+        request_info=RequestInfo(
+            url="https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1/homes",  # type: ignore
+            method="GET",
+            headers=None,  # type: ignore
+        ),
+        history=None,  # type: ignore
+        status=403,
+        message='{ "statusCode": 403, "message": "Out of call volume quota. Quota will be replenished in 00:30:02." }',
+        headers={"Retry-After": "900"},  # type: ignore
+    )
+    # Header value (900) should win over body text (1802)
+    assert extract_quota_duration(exc) == 900
+
+
+async def test_quota_duration_falls_back_to_body_without_header():
+    """Without Retry-After header, body text parsing is still used."""
+    exc = ClientResponseError(
+        request_info=RequestInfo(
+            url="https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1/homes",  # type: ignore
+            method="GET",
+            headers=None,  # type: ignore
+        ),
+        history=None,  # type: ignore
+        status=403,
+        message='{ "statusCode": 403, "message": "Out of call volume quota. Quota will be replenished in 01:00:00." }',
+    )
+    assert extract_quota_duration(exc) == 3600
+
+
+async def test_quota_duration_invalid_retry_after_falls_back_to_body():
+    """Non-integer Retry-After should fall back to body text parsing."""
+    exc = ClientResponseError(
+        request_info=RequestInfo(
+            url="https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1/homes",  # type: ignore
+            method="GET",
+            headers=None,  # type: ignore
+        ),
+        history=None,  # type: ignore
+        status=403,
+        message='{ "statusCode": 403, "message": "Out of call volume quota. Quota will be replenished in 00:45:00." }',
+        headers={"Retry-After": "not-a-number"},  # type: ignore
+    )
+    assert extract_quota_duration(exc) == 45 * 60
+
+
 async def test_quota_end_time(
     mypyllant_aioresponses, mocked_api: MyPyllantAPI, system_coordinator_mock
 ):


### PR DESCRIPTION
extract_quota_duration() now checks the Retry-After response header (RFC 7231 §7.1.3) before falling back to parsing the body text for the Vaillant-specific 'Quota will be replenished in HH:MM:SS' message.

aiohttp's raise_for_status() already preserves response headers on ClientResponseError, so no changes to the myPyllant library are needed.

This gives more accurate backoff times since the header value comes directly from the API gateway, whereas the body text can differ or be absent.

4 new test cases covering: header-only, header-takes-precedence, fallback-to-body, and invalid-header-falls-back-to-body.

Closes #366