### PR TITLE
guard against mising zone for holidays as well

### DIFF
--- a/custom_components/mypyllant/utils.py
+++ b/custom_components/mypyllant/utils.py
@@ -133,7 +133,7 @@ class HolidayEntity(SystemCoordinatorEntity):
             if self.zone
             else False,
             "holiday_remaining_seconds": self.zone.general.holiday_remaining.total_seconds()
-            if self.zone.general.holiday_remaining
+            if self.zone and self.zone.general.holiday_remaining
             else None,
             "holiday_start_date_time": self.holiday_start,
             "holiday_end_date_time": self.holiday_end,


### PR DESCRIPTION
We encountered a failure in tests when building the mypyllant component in the NixOS CI (see https://github.com/NixOS/nixpkgs/pull/523097; although the error is not visible in that PR, unfortunately no logs are provided there).

The failure happened in `tests/test_services.py::test_service_generate_test_data` with the following error:
```
  File "mypyllant-component/custom_components/mypyllant/utils.py", line 136, in extra_state_attributes
    if self.zone.general.holiday_remaining
       ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'general'
```

I believe the fix is to do the same guard around `self.zone` as in line 133.