### PR TITLE
Fix mypyllant.report crash: datetime module shadowing (#199)

### DIFF
--- a/custom_components/mypyllant/__init__.py
+++ b/custom_components/mypyllant/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime as dt, timedelta, datetime
+from datetime import datetime as dt, timedelta
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -162,7 +162,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 password=password,
                 brand=brand,
                 country=country,
-                year=int(call.data.get("year", datetime.now().year)),
+                year=int(call.data.get("year", dt.now().year)),
                 write_results=False,
             )
         }


### PR DESCRIPTION
## Problem

Calling the `mypyllant.report` service raises (see #199):

```
AttributeError: module 'custom_components.mypyllant.datetime' has no attribute 'now'
```

Reproduced on 0.9.16 / HA Core 2026.5.4.

## Root cause

The package ships a `datetime.py` platform module. When Home Assistant loads the
datetime platform, Python binds the submodule as an attribute of the package
(`custom_components.mypyllant.datetime = <module>`). Because `__init__.py` does
`from datetime import datetime`, that import binds the **class** to the package-level
name `datetime` — which the submodule import then **clobbers**. After platforms load,
`handle_report` calls `datetime.now()`, now resolving to the platform *module* instead
of the class → `AttributeError`.

## Fix

Use the existing `dt` alias (same class) in `handle_report`, matching what the service
schema default already does (`dt.now().year` at the `Required("year", ...)` line), and
drop the redundant/footgun bare `datetime` import. Two-line change, no behaviour change.

Fixes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)