### PR TITLE
Fix VRC700 ventilation: send DAY/SET_BACK instead of NORMAL/REDUCED

### DIFF
--- a/custom_components/mypyllant/ventilation_climate.py
+++ b/custom_components/mypyllant/ventilation_climate.py
@@ -35,6 +35,18 @@ _FAN_STAGE_TYPE_OPTIONS = [
     for v in VentilationFanStageType
 ]
 
+# VRC700 ventilation only accepts DAY / SET_BACK / AUTO on the operation-mode
+# endpoint; OFF / NORMAL / REDUCED are rejected with HTTP 400
+# (MalformedRequestParameters / G003). The read-side ``fan_mode_map`` keeps the
+# full set so the displayed ``fan_mode`` stays correct whatever the device
+# reports, while writes must use this VRC700-specific mapping.
+# Verified against the myVAILLANT API on a recoVAIR VAR 260/4 (VRC700).
+VRC700_FAN_MODE_WRITE_MAP = {
+    FAN_ON: VentilationOperationModeVRC700.DAY,
+    FAN_LOW: VentilationOperationModeVRC700.SET_BACK,
+    FAN_AUTO: VentilationOperationModeVRC700.AUTO,
+}
+
 
 class VentilationClimate(CoordinatorEntity, ClimateEntity):
     """
@@ -137,6 +149,8 @@ class VentilationClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def fan_modes(self) -> list[str]:
+        if self.ventilation.control_identifier.is_vrc700:
+            return list(VRC700_FAN_MODE_WRITE_MAP.keys())
         return [str(k) for k in self.fan_mode_map.values()]
 
     @ensure_token_refresh
@@ -153,7 +167,10 @@ class VentilationClimate(CoordinatorEntity, ClimateEntity):
 
     @ensure_token_refresh
     async def async_set_fan_mode(self, fan_mode: str) -> None:
-        mode = [k for k, v in self.fan_mode_map.items() if v == fan_mode][0]
+        if self.ventilation.control_identifier.is_vrc700:
+            mode = VRC700_FAN_MODE_WRITE_MAP[fan_mode]
+        else:
+            mode = [k for k, v in self.fan_mode_map.items() if v == fan_mode][0]
         await self.coordinator.api.set_ventilation_operation_mode(
             self.ventilation,
             mode,

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -2,13 +2,20 @@ from unittest import mock
 
 import pytest as pytest
 from homeassistant.components.climate import HVACMode, PRESET_NONE
-from homeassistant.components.climate.const import FAN_OFF, PRESET_BOOST
+from homeassistant.components.climate.const import (
+    FAN_AUTO,
+    FAN_LOW,
+    FAN_OFF,
+    FAN_ON,
+    PRESET_BOOST,
+)
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_registry import DATA_REGISTRY, EntityRegistry
 from homeassistant.loader import DATA_COMPONENTS, DATA_INTEGRATIONS
 
 from myPyllant.api import MyPyllantAPI
+from myPyllant.enums import VentilationOperationModeVRC700
 from myPyllant.tests.generate_test_data import DATA_DIR
 from myPyllant.tests.utils import list_test_data, load_test_data
 
@@ -125,7 +132,21 @@ async def test_ventilation_climate(
         assert isinstance(ventilation.hvac_mode, HVACMode)
         assert isinstance(ventilation.fan_mode, str)
 
-        await ventilation.async_set_fan_mode(FAN_OFF)
+        if ventilation.ventilation.control_identifier.is_vrc700:
+            # VRC700 only accepts DAY / SET_BACK / AUTO on the operation-mode
+            # endpoint; OFF / NORMAL / REDUCED are rejected by the API, so they
+            # must neither be advertised nor sent.
+            assert ventilation.fan_modes == [FAN_ON, FAN_LOW, FAN_AUTO]
+            with mock.patch.object(
+                system_coordinator_mock.api, "set_ventilation_operation_mode"
+            ) as mock_set:
+                await ventilation.async_set_fan_mode(FAN_ON)
+                assert (
+                    mock_set.await_args.args[1] == VentilationOperationModeVRC700.DAY
+                )
+        else:
+            await ventilation.async_set_fan_mode(FAN_OFF)
+
         system_coordinator_mock._debounced_refresh.async_cancel()
     await mocked_api.aiohttp_session.close()
 


### PR DESCRIPTION
## Problem

On VRC700 controllers (e.g. sensoCOMFORT) `climate.set_fan_mode` fails for the ventilation entity for every mode except `auto`. Each call returns a 500 in Home Assistant because the myVAILLANT API rejects the request:

```
PATCH .../vrc700/v1/systems/<id>/ventilation/0/operation-mode  -> 400
{"title":"MalformedRequestParameters","status":400,"errorCode":"G003"}
```

### Root cause

`async_set_fan_mode` resolves the operation mode with
`[k for k, v in self.fan_mode_map.items() if v == fan_mode][0]`.
The VRC700 `fan_mode_map` maps **both** `NORMAL → FAN_ON` and `DAY → FAN_ON`
(and `REDUCED → FAN_LOW`, `SET_BACK → FAN_LOW`). `[0]` therefore picks
`NORMAL` / `REDUCED`, which the VRC700 ventilation endpoint does not accept.

I verified directly against the API (authenticated, raw PATCH bodies) which
`operationMode` values a VRC700 accepts:

| value | result |
|---|---|
| `AUTO`, `DAY`, `SET_BACK` | ✅ 202 |
| `NORMAL`, `REDUCED`, `OFF` | ❌ 400 (G003) |

## Fix

- Add `VRC700_FAN_MODE_WRITE_MAP` (`on → DAY`, `low → SET_BACK`, `auto → AUTO`)
  and use it in `async_set_fan_mode` for VRC700.
- Advertise only `[on, low, auto]` in `fan_modes` for VRC700 (`off` is rejected
  by the API; this also drops the duplicate entries).
- The read-side `fan_mode_map` is left untouched, so the displayed `fan_mode`
  stays correct for whatever mode the device reports.

Updated `tests/test_climate.py::test_ventilation_climate` to assert the VRC700
fan modes and that `on` is sent as `DAY`.

Tested live on a recoVAIR VAR 260/4 (VRC700): `climate.set_fan_mode` on/low/auto
→ 200, and the unit follows.

Related to #210 and #206 (same class of VRC700 write rejection).

## Note (separate, not fixed here)

`mypyllant.set_ventilation_fan_stage` also fails on VRC700:
`PATCH .../ventilation/0/fan-stage` returns **404** — the fan-stage endpoint
does not exist for VRC700. That likely warrants hiding the service / raising a
clear "not supported on VRC700" error (like ventilation boost). Left out here to
keep this PR focused.
