### PR TITLE
Fix Python 2 exception syntax that breaks import on Python 3

### DIFF
--- a/custom_components/mypyllant/calendar.py
+++ b/custom_components/mypyllant/calendar.py
@@ -127,7 +127,7 @@ class BaseCalendarEntity(CalendarEntity, ABC):
         match = re.search(r"([0-9.,]+)°?C?", summary)
         try:
             return float(match.group(1).replace(",", "."))  # type: ignore
-        except ValueError, AttributeError:
+        except (ValueError, AttributeError):
             raise HomeAssistantError("Invalid setpoint, use format '21.5°C' in Summary")
 
     def _check_overlap(self):

--- a/custom_components/mypyllant/utils.py
+++ b/custom_components/mypyllant/utils.py
@@ -245,7 +245,7 @@ def extract_quota_duration(exc_info: BaseException | None) -> int | None:
     if retry_after is not None:
         try:
             return int(retry_after)
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             pass
 
     import re

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -13,12 +13,14 @@ from myPyllant.tests.generate_test_data import DATA_DIR
 from myPyllant.tests.utils import list_test_data, load_test_data
 
 from custom_components.mypyllant.calendar import (
+    BaseCalendarEntity,
     ZoneHeatingCalendar,
     DomesticHotWaterCalendar,
     async_setup_entry,
     DomesticHotWaterCirculationCalendar,
     AmbisenseCalendar,
 )
+from homeassistant.exceptions import HomeAssistantError
 from tests.utils import get_config_entry
 
 
@@ -310,3 +312,10 @@ async def test_zone_heating_current_event_selection(
             assert event.end.time() == time(0, 0, 0)
 
     await mocked_api.aiohttp_session.close()
+
+
+def test_get_setpoint_from_summary():
+    assert BaseCalendarEntity.get_setpoint_from_summary("Heating to 21.0°C") == 21.0
+    assert BaseCalendarEntity.get_setpoint_from_summary("Heating to 20,5°C") == 20.5
+    with pytest.raises(HomeAssistantError):
+        BaseCalendarEntity.get_setpoint_from_summary("no temperature here")


### PR DESCRIPTION
`utils.py` and `calendar.py` both use the old `except ValueError, TypeError:` form, which is a SyntaxError on Python 3 and prevents the integration from loading on Home Assistant 2026.7 (Python 3.13+). Parenthesized both into `except (ValueError, TypeError):` / `except (ValueError, AttributeError):` and added a small test for `get_setpoint_from_summary`.

Fixes #464